### PR TITLE
[bootloader] Add loongarch64 support for bootloader

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -401,6 +401,8 @@ def get_grub_efi_parameters():
         return ("i386-efi", "grubia32.efi", "bootia32.efi")
     elif efi_bitness == "64" and cpu_type == "aarch64":
         return ("arm64-efi", "grubaa64.efi", "bootaa64.efi")
+    elif efi_bitness == "64" and cpu_type == "loongarch64":
+        return ("loongarch64-efi", "grubloongarch64.efi", "bootloongarch64.efi")
     elif efi_bitness == "64":
         # If it's not ARM, must by AMD64
         return ("x86_64-efi", "grubx64.efi", "bootx64.efi")


### PR DESCRIPTION
 Let calamares installer add loongarch64 architecture